### PR TITLE
Avoid depending on exceptiongroup backport package on Python 3.11 and later

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ python = ">=3.8"
 hypercorn = { version = ">=0.12.0", extras = ["trio"] }
 quart = ">=0.19"
 trio = ">=0.19.0"
-exceptiongroup = ">=1.0.0"
+exceptiongroup = { version = ">= 1.1.0", python = "<3.11" }
 
 [tool.poetry.dev-dependencies]
 tox = "*"

--- a/src/quart_trio/app.py
+++ b/src/quart_trio/app.py
@@ -3,7 +3,6 @@ import warnings
 from typing import Any, Awaitable, Callable, Coroutine, Optional, TypeVar, Union
 
 import trio
-from exceptiongroup import BaseExceptionGroup
 from hypercorn.config import Config as HyperConfig
 from hypercorn.trio import serve
 from quart import Quart, request_started, websocket_started
@@ -24,6 +23,9 @@ try:
     from typing import ParamSpec
 except ImportError:
     from typing_extensions import ParamSpec  # type: ignore
+
+if sys.version_info < (3, 11):
+    from exceptiongroup import BaseExceptionGroup
 
 T = TypeVar("T")
 P = ParamSpec("P")

--- a/src/quart_trio/asgi.py
+++ b/src/quart_trio/asgi.py
@@ -1,9 +1,9 @@
 from functools import partial
+import sys
 from typing import cast, Optional, TYPE_CHECKING, Union
 from urllib.parse import urlparse
 
 import trio
-from exceptiongroup import BaseExceptionGroup
 from hypercorn.typing import (
     ASGIReceiveCallable,
     ASGISendCallable,
@@ -21,6 +21,9 @@ from werkzeug.datastructures import Headers
 
 if TYPE_CHECKING:
     from quart_trio import QuartTrio  # noqa: F401
+
+if sys.version_info < (3, 11):
+    from exceptiongroup import BaseExceptionGroup
 
 
 class TrioASGIHTTPConnection(ASGIHTTPConnection):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,11 +1,14 @@
 from typing import NoReturn
+import sys
 
 import pytest
-from exceptiongroup import BaseExceptionGroup
 from quart import ResponseReturnValue
 from quart.testing import WebsocketResponseError
 
 from quart_trio import QuartTrio
+
+if sys.version_info < (3, 11):
+    from exceptiongroup import BaseExceptionGroup
 
 
 @pytest.fixture(name="error_app", scope="function")


### PR DESCRIPTION
The first commit conditionalizes the imports, as is the status quo in Hypercorn.

The second commit conditionalizes the dependency, corresponding to https://github.com/pgjones/hypercorn/pull/185.

I’m working on packaging hypercorn, Quart, and quart-trio for Fedora Linux, and this helps me avoid introducing a `python-exceptiongroup` package too. (We only have Python 3.11 and later as the system Python in supported releases.)